### PR TITLE
Change m_ctxEntryMassModify to m_ctxEntryEditQuick

### DIFF
--- a/KeePassTimestampChangerExt.cs
+++ b/KeePassTimestampChangerExt.cs
@@ -35,7 +35,7 @@ namespace KeePassTimestampChanger
 			
 			GlobalWindowManager.WindowAdded += WindowAddedHandler;
 
-			var m_ctxEntryMassModify = host.MainWindow.EntryContextMenu.Items.Find("m_ctxEntryMassModify", false).FirstOrDefault() as ToolStripMenuItem;
+			var m_ctxEntryMassModify = host.MainWindow.EntryContextMenu.Items.Find("m_ctxEntryEditQuick", false).FirstOrDefault() as ToolStripMenuItem;
 			if (m_ctxEntryMassModify != null)
 			{
 				ctxItem = CreateToolStripItem(() =>


### PR DESCRIPTION
Per
https://sourceforge.net/p/keepass/discussion/329220/thread/5ef408ed35/?limit=25&page=1#50cb/8f35

In KeePass 2.43, this fix changes this:
![2020-01-10_03-52-59PMKeePass-%t](https://user-images.githubusercontent.com/220772/72194206-a3eacc00-33c1-11ea-84cc-d159a0d4b9b2.png)
to this:
![2020-01-10_03-53-38PMKeePass-%t](https://user-images.githubusercontent.com/220772/72194205-a3523580-33c1-11ea-8ffe-dbfb6e8b7dd1.png)